### PR TITLE
visicamRPiGPU integration, matrix caching

### DIFF
--- a/html/configPage.html
+++ b/html/configPage.html
@@ -29,7 +29,7 @@
       <p class="visicamRPiGPU"><label for="visicamRPiGPUBinaryPath">BinaryPath:</label><input id="visicamRPiGPUBinaryPath" name="visicamRPiGPUBinaryPath" type="text"/></p>
       <p class="visicamRPiGPU"><label for="visicamRPiGPUMatrixPath">MatrixPath:</label><input id="visicamRPiGPUMatrixPath" name="visicamRPiGPUMatrixPath" type="text"/></p>
       <p class="visicamRPiGPU"><label for="visicamRPiGPUImageOriginalPath">OriginalImagePath:</label><input id="visicamRPiGPUImageOriginalPath" name="visicamRPiGPUImageOriginalPath" type="text"/></p>
-      <p class="visicamRPiGPU"><label for="visicamRPiGPUImageProcessedPath">FinalImagePath:</label><input id="visicamRPiGPUImageProcessedPath" name="visicamRPiGPUImageProcessedPath" type="text"/><br><br>(For visicamRPiGPU ensure that InputWidth == OutputWidth and InputHeight == OutputHeight)</p>
+      <p class="visicamRPiGPU"><label for="visicamRPiGPUImageProcessedPath">FinalImagePath:</label><input id="visicamRPiGPUImageProcessedPath" name="visicamRPiGPUImageProcessedPath" type="text"/><br><br>For visicamRPiGPU ensure that: InputWidth == OutputWidth, InputHeight == OutputHeight,<br>enough GPU split memory in raspi-config (1280x720 => 128 MB),<br>width in [640, 1920], height in [480, 1080],<br>width multiple of 32, height multiple of 16</p>
       <hr>
       <!-- visicamRPiGPU integration end -->
       <p><label for="marker">Marker:</label>

--- a/html/configPage.html
+++ b/html/configPage.html
@@ -17,6 +17,7 @@
       <p><label for="inputHeight">InputHeight:</label><input id="inputHeight" name="inputHeight" type="number"/></p>
       <p><label for="outputWidth">OutputWidth:</label><input id="outputWidth" name="outputWidth" type="number"/></p>
       <p><label for="outputHeight">OutputHeight:</label><input id="outputHeight" name="outputHeight" type="number"/></p>
+      <p><label for="refreshSeconds">RefreshSeconds:</label><input id="refreshSeconds" name="refreshSeconds" type="number"/></p>
       <p><label for="lockInsecureSettings">lockInsecureSettings:</label><input id="lockInsecureSettings" name="lockInsecureSettings" type="checkbox"/>(set customCapture, captureCommand and captureResult read-only.<br>If this is disabled, anyone can execute arbitrary commands as the user running VisiCam!<br> once enabled, this can only be disabled from config file)</p>
       <hr>
       <p><label for="customCapture">CustomCapture:</label><input id="customCapture" name="customCapture" type="checkbox"/></p>
@@ -28,8 +29,7 @@
       <p class="visicamRPiGPU"><label for="visicamRPiGPUBinaryPath">BinaryPath:</label><input id="visicamRPiGPUBinaryPath" name="visicamRPiGPUBinaryPath" type="text"/></p>
       <p class="visicamRPiGPU"><label for="visicamRPiGPUMatrixPath">MatrixPath:</label><input id="visicamRPiGPUMatrixPath" name="visicamRPiGPUMatrixPath" type="text"/></p>
       <p class="visicamRPiGPU"><label for="visicamRPiGPUImageOriginalPath">OriginalImagePath:</label><input id="visicamRPiGPUImageOriginalPath" name="visicamRPiGPUImageOriginalPath" type="text"/></p>
-      <p class="visicamRPiGPU"><label for="visicamRPiGPUImageProcessedPath">FinalImagePath:</label><input id="visicamRPiGPUImageProcessedPath" name="visicamRPiGPUImageProcessedPath" type="text"/></p>
-      <p class="visicamRPiGPU"><label for="visicamRPiGPURefreshSeconds">RefreshSeconds:</label><input id="visicamRPiGPURefreshSeconds" name="visicamRPiGPURefreshSeconds" type="number"/><br><br>(For visicamRPiGPU ensure that InputWidth == OutputWidth and InputHeight == OutputHeight)</p>
+      <p class="visicamRPiGPU"><label for="visicamRPiGPUImageProcessedPath">FinalImagePath:</label><input id="visicamRPiGPUImageProcessedPath" name="visicamRPiGPUImageProcessedPath" type="text"/><br><br>(For visicamRPiGPU ensure that InputWidth == OutputWidth and InputHeight == OutputHeight)</p>
       <hr>
       <!-- visicamRPiGPU integration end -->
       <p><label for="marker">Marker:</label>
@@ -64,20 +64,20 @@
       $("#inputHeight").val(settings.inputHeight);
       $("#outputWidth").val(settings.outputWidth);
       $("#outputHeight").val(settings.outputHeight);
+      $("#refreshSeconds").val(settings.refreshSeconds);
       $("#lockInsecureSettings").attr("checked",settings.lockInsecureSettings);
 
       // visicamRPiGPU integration start
       // Ensure that InputWidth == OutputWidth and InputHeight == OutputHeight for visicamRPiGPU
       if (settings.visicamRPiGPUBinaryPath != "" && settings.visicamRPiGPUMatrixPath != "" && settings.visicamRPiGPUImageOriginalPath != "" &&
-          settings.visicamRPiGPUImageProcessedPath != "" && settings.visicamRPiGPURefreshSeconds != "" &&
-          settings.inputWidth == settings.outputWidth && settings.inputHeight == settings.outputHeight)
+          settings.visicamRPiGPUImageProcessedPath != "" && settings.inputWidth == settings.outputWidth && settings.inputHeight == settings.outputHeight)
       {
         $("#visicamRPiGPUEnabled").attr("checked", "checked");
         $("#visicamRPiGPUBinaryPath").val(settings.visicamRPiGPUBinaryPath);
         $("#visicamRPiGPUMatrixPath").val(settings.visicamRPiGPUMatrixPath);
         $("#visicamRPiGPUImageOriginalPath").val(settings.visicamRPiGPUImageOriginalPath);
         $("#visicamRPiGPUImageProcessedPath").val(settings.visicamRPiGPUImageProcessedPath);
-        $("#visicamRPiGPURefreshSeconds").val(settings.visicamRPiGPURefreshSeconds);
+        
       }
       else
       {
@@ -110,7 +110,6 @@
         $("#visicamRPiGPUMatrixPath").attr("readonly",true);
         $("#visicamRPiGPUImageOriginalPath").attr("readonly",true);
         $("#visicamRPiGPUImageProcessedPath").attr("readonly",true);
-        $("#visicamRPiGPURefreshSeconds").attr("readonly",true);
         // visicamRPiGPU integration end
       }
 
@@ -184,6 +183,7 @@
       settings.inputHeight = $("#inputHeight").val();
       settings.outputWidth = $("#outputWidth").val();
       settings.outputHeight = $("#outputHeight").val();
+      settings.refreshSeconds = $("#refreshSeconds").val();
       settings.captureCommand = $("#customCapture").is(":checked") ? $("#captureCommand").val() : "";
       settings.captureResult = $("#customCapture").is(":checked") ? $("#captureResult").val() : "";
       settings.lockInsecureSettings = $("#lockInsecureSettings").is(":checked");
@@ -193,7 +193,6 @@
       settings.visicamRPiGPUMatrixPath = $("#visicamRPiGPUEnabled").is(":checked") ? $("#visicamRPiGPUMatrixPath").val() : "";
       settings.visicamRPiGPUImageOriginalPath = $("#visicamRPiGPUEnabled").is(":checked") ? $("#visicamRPiGPUImageOriginalPath").val() : "";
       settings.visicamRPiGPUImageProcessedPath = $("#visicamRPiGPUEnabled").is(":checked") ? $("#visicamRPiGPUImageProcessedPath").val() : "";
-      settings.visicamRPiGPURefreshSeconds = $("#visicamRPiGPUEnabled").is(":checked") ? $("#visicamRPiGPURefreshSeconds").val() : 0;
       // visicamRPiGPU integration end
 
       $.post("../settings", settings, function(){alert("Settings saved")});

--- a/src/com/t_oster/visicam/VisiCamServer.java
+++ b/src/com/t_oster/visicam/VisiCamServer.java
@@ -34,7 +34,7 @@ public class VisiCamServer extends NanoHTTPD
   private int inputHeight = 1050;
   private int outputWidth = 1680;
   private int outputHeight = 1050;
-  private Integer refreshSeconds = 0;
+  private Integer refreshSeconds = 5;
   private boolean lockInsecureSettings = false;
 
   // visicamRPiGPU integration start
@@ -117,6 +117,32 @@ public class VisiCamServer extends NanoHTTPD
     lockInsecureSettings = Boolean.parseBoolean(parms.getProperty("lockInsecureSettings"));
     captureCommand = parms.getProperty("captureCommand");
     captureResult = parms.getProperty("captureResult");
+
+    // Ensure that there are positive values for some integer values
+    if (inputWidth <= 0)
+    {
+        inputWidth = 1680;
+    }
+
+    if (inputHeight <= 0)
+    {
+        inputHeight = 1050;
+    }
+
+    if (outputWidth <= 0)
+    {
+        outputWidth = 1680;
+    }
+
+    if (outputHeight <= 0)
+    {
+        outputHeight = 1050;
+    }
+
+    if (refreshSeconds <= 0)
+    {
+        refreshSeconds = 5;
+    }
 
     // visicamRPiGPU integration start
     visicamRPiGPUBinaryPath = parms.getProperty("visicamRPiGPUBinaryPath");

--- a/src/com/t_oster/visicam/VisiCamServer.java
+++ b/src/com/t_oster/visicam/VisiCamServer.java
@@ -34,6 +34,7 @@ public class VisiCamServer extends NanoHTTPD
   private int inputHeight = 1050;
   private int outputWidth = 1680;
   private int outputHeight = 1050;
+  private Integer refreshSeconds = 0;
   private boolean lockInsecureSettings = false;
 
   // visicamRPiGPU integration start
@@ -41,7 +42,6 @@ public class VisiCamServer extends NanoHTTPD
   private String visicamRPiGPUMatrixPath = "";
   private String visicamRPiGPUImageOriginalPath = "";
   private String visicamRPiGPUImageProcessedPath = "";
-  private Integer visicamRPiGPURefreshSeconds = 0;
   // visicamRPiGPU integration end
 
   private Gson gson = new Gson();
@@ -91,6 +91,7 @@ public class VisiCamServer extends NanoHTTPD
     settings.put("inputHeight", inputHeight);
     settings.put("outputWidth", outputWidth);
     settings.put("outputHeight", outputHeight);
+    settings.put("refreshSeconds", refreshSeconds);
     settings.put("captureCommand", captureCommand);
     settings.put("captureResult", captureResult);
     settings.put("lockInsecureSettings", lockInsecureSettings);
@@ -100,7 +101,6 @@ public class VisiCamServer extends NanoHTTPD
     settings.put("visicamRPiGPUMatrixPath", visicamRPiGPUMatrixPath);
     settings.put("visicamRPiGPUImageOriginalPath", visicamRPiGPUImageOriginalPath);
     settings.put("visicamRPiGPUImageProcessedPath", visicamRPiGPUImageProcessedPath);
-    settings.put("visicamRPiGPURefreshSeconds", visicamRPiGPURefreshSeconds);
     // visicamRPiGPU integration end
 
     return new Response(HTTP_OK, "application/json", gson.toJson(settings));
@@ -113,6 +113,7 @@ public class VisiCamServer extends NanoHTTPD
     inputHeight = Integer.parseInt(parms.getProperty("inputHeight"));
     outputWidth = Integer.parseInt(parms.getProperty("outputWidth"));
     outputHeight = Integer.parseInt(parms.getProperty("outputHeight"));
+    refreshSeconds = Integer.parseInt(parms.getProperty("refreshSeconds"));
     lockInsecureSettings = Boolean.parseBoolean(parms.getProperty("lockInsecureSettings"));
     captureCommand = parms.getProperty("captureCommand");
     captureResult = parms.getProperty("captureResult");
@@ -122,7 +123,6 @@ public class VisiCamServer extends NanoHTTPD
     visicamRPiGPUMatrixPath = parms.getProperty("visicamRPiGPUMatrixPath");
     visicamRPiGPUImageOriginalPath = parms.getProperty("visicamRPiGPUImageOriginalPath");
     visicamRPiGPUImageProcessedPath = parms.getProperty("visicamRPiGPUImageProcessedPath");
-    visicamRPiGPURefreshSeconds = Integer.parseInt(parms.getProperty("visicamRPiGPURefreshSeconds"));
     // visicamRPiGPU integration end
 
     for (int i = 0; i < markerSearchfields.length; i++)
@@ -151,7 +151,6 @@ public class VisiCamServer extends NanoHTTPD
           parms.setProperty("visicamRPiGPUMatrixPath", visicamRPiGPUMatrixPath);
           parms.setProperty("visicamRPiGPUImageOriginalPath", visicamRPiGPUImageOriginalPath);
           parms.setProperty("visicamRPiGPUImageProcessedPath", visicamRPiGPUImageProcessedPath);
-          parms.setProperty("visicamRPiGPURefreshSeconds", visicamRPiGPURefreshSeconds.toString());
           // visicamRPiGPU integration end
       }
       parms.store(new FileOutputStream(config), "VisiCam Configuration");

--- a/src/com/t_oster/visicam/VisiCamServer.java
+++ b/src/com/t_oster/visicam/VisiCamServer.java
@@ -162,7 +162,7 @@ public class VisiCamServer extends NanoHTTPD
 
     if (refreshSeconds <= 0)
     {
-        refreshSeconds = 5;
+        refreshSeconds = 30;
     }
 
     // visicamRPiGPU integration start


### PR DESCRIPTION
In this pull request the integration for the visicamRPiGPU project (https://github.com/FroChr123/visicamRPiGPU) is implemented. VisiCam sets the settings for this project and manages the starting / restarting / stopping of its binary. It provides fast computations for the image processing. Currently the system aims at 50ms refresh rate for a resolution of 1280 x 720.

Additionally, the matrix values are cached for some time. They should not be computed on each request because of performance and they should not only be set once because the marker positions might slightly change (e.g. moving up / down of the laser-cutter surface).