### PR TITLE
visicamRPiGPU: Close all files correctly

### DIFF
--- a/src/com/t_oster/visicam/CameraController.java
+++ b/src/com/t_oster/visicam/CameraController.java
@@ -71,8 +71,9 @@ public class CameraController
             Path originalImagePath = Paths.get(visicamRPiGPUImageOriginalPath);
             byte[] originalImageFileData = Files.readAllBytes(originalImagePath);
 
-            // Unlock file
+            // Unlock, close file
             originalImageLock.release();
+            originalImageChannel.close();
 
             // Create input stream from memory file data
             ByteArrayInputStream originalImageByteInputStream = new ByteArrayInputStream(originalImageFileData);
@@ -244,8 +245,9 @@ public class CameraController
         matrixOutputWriter.flush();
         matrixOutputWriter.close();
 
-        // Unlock file
+        // Unlock, close file
         matrixOutputLock.release();
+        matrixOutputChannel.close();
     }
 
     // This looks weird, but homographyMatrix must not be null for synchronized access

--- a/src/com/t_oster/visicam/VisiCamServer.java
+++ b/src/com/t_oster/visicam/VisiCamServer.java
@@ -405,8 +405,9 @@ public class VisiCamServer extends NanoHTTPD
             Path processedImagePath = Paths.get(visicamRPiGPUImageProcessedPath);
             byte[] processedImageFileData = Files.readAllBytes(processedImagePath);
 
-            // Unlock file
+            // Unlock, close file
             processedImageLock.release();
+            processedImageChannel.close();
 
             // Create input stream from memory file data
             ByteArrayInputStream processedImageByteInputStream = new ByteArrayInputStream(processedImageFileData);
@@ -526,7 +527,9 @@ public class VisiCamServer extends NanoHTTPD
                     if (config.exists())
                     {
                         Properties p = new Properties();
-                        p.load(new FileInputStream(config));
+                        FileInputStream inputStream = new FileInputStream(config);
+                        p.load(inputStream);
+                        inputStream.close();
                         loadProperties(p);
                     }
                 }


### PR DESCRIPTION
As it seems I missed the closing of file descriptors, its a bit confusing that the File class in Java is not responsible for that, but its spread around other classes. :)

Ran 30 minutes now with 50ms intervals without getting into trouble because of it, when I got the error I think the time interval was way smaller.