### PR TITLE
Improve image error handling

### DIFF
--- a/src/com/t_oster/visicam/CameraController.java
+++ b/src/com/t_oster/visicam/CameraController.java
@@ -194,17 +194,19 @@ public class CameraController
   
   public BufferedImage applyHomography(BufferedImage img)
   {
-    if (homographyMatrix != null)
-    {
         synchronized (synchronizedMatrix)
         {
-            IplImage in = IplImage.createFrom(img);
-            cvWarpPerspective(in, in, homographyMatrix);
-            return in.getBufferedImage();
+            if (homographyMatrix != null)
+            {
+                IplImage in = IplImage.createFrom(img);
+                cvWarpPerspective(in, in, homographyMatrix);
+                return in.getBufferedImage();
+            }
+            else
+            {
+                return null;
+            }
         }
-    }
-
-    return null;
   }
 
   public void updateHomographyMatrix(BufferedImage img, RelativePoint[] markerPositions, double ouputWidth, double outputHeight, boolean visicamRPiGPUEnabled, String visicamRPiGPUMatrixPath) throws FileNotFoundException, IOException
@@ -276,6 +278,17 @@ public class CameraController
     else
     {
         homographyMatrix = localHomographyMatrix;
+    }
+  }
+  
+  public void setHomographyMatrixInvalid()
+  {
+    if (homographyMatrix != null)
+    {
+        synchronized (synchronizedMatrix)
+        {
+            homographyMatrix = null;
+        }
     }
   }
 


### PR DESCRIPTION
yet to be tested:

- Show error message if the homography matrix could not be refreshed, even if there is a previous valid homography matrix.
(this was probably a regression)
- When the markers are not found, output HTTP 503 + Retry-After header, so that this (most probably temporary) error can be handled differently by VisiCut (still to do there)