### PR TITLE
Cache response, always update homography matrix except on Raspi

### DIFF
--- a/html/configPage.html
+++ b/html/configPage.html
@@ -192,7 +192,7 @@
       settings.lockInsecureSettings = $("#lockInsecureSettings").is(":checked");
 
       // visicamRPiGPU integration start
-      settings.visicamRPiGPUInactivitySeconds = $("#visicamRPiGPUEnabled").is(":checked") ? $("#visicamRPiGPUInactivitySeconds").val() : "";
+      settings.visicamRPiGPUInactivitySeconds = $("#visicamRPiGPUEnabled").is(":checked") ? $("#visicamRPiGPUInactivitySeconds").val() : "0";
       settings.visicamRPiGPUBinaryPath = $("#visicamRPiGPUEnabled").is(":checked") ? $("#visicamRPiGPUBinaryPath").val() : "";
       settings.visicamRPiGPUMatrixPath = $("#visicamRPiGPUEnabled").is(":checked") ? $("#visicamRPiGPUMatrixPath").val() : "";
       settings.visicamRPiGPUImageOriginalPath = $("#visicamRPiGPUEnabled").is(":checked") ? $("#visicamRPiGPUImageOriginalPath").val() : "";

--- a/src/com/t_oster/visicam/CachingAsynchronousHandler.java
+++ b/src/com/t_oster/visicam/CachingAsynchronousHandler.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2015 Max Gaukler <development@maxgaukler.de>
+ */
+package com.t_oster.visicam;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * cache a time-intensive computation
+ *
+ * @param <CacheType> datatype for internal cache (result of computation)
+ * @param <ResultType> return datatype for getFreshResultBlocking() and
+ * getCachedResult()
+ */
+public class CachingAsynchronousHandler<CacheType, ResultType> {
+    final Object lockThread;
+    final Object lockCache;
+    CacheType cache;
+    Thread thread;
+    Computation<CacheType, ResultType> computation;
+
+    /**
+     * @param computeCacheEntry computation object (wrapper around functions that do the work)
+     */
+    public CachingAsynchronousHandler(Computation<CacheType, ResultType> computeCacheEntry) {
+        this.lockThread = new Object();
+        this.lockCache = new Object();
+        this.cache = null;
+        this.thread = null;
+        this.computation = computeCacheEntry;
+    }
+    
+    /**
+     * Interface for a function that returns a value.
+     * Similar to Runnable, but it can return a value
+     * and may be called multiple times.
+     *
+     * @param <CacheType> type for cache entry
+     * @param <ResultType> type for final result (often same as cache entry)
+     */
+    public interface Computation<CacheType, ResultType> {
+
+        /**
+         * compute cache entry (usually time-intensive)
+         *
+         * @return result
+         */
+        abstract public CacheType computeCacheEntry();
+        
+        /**
+        * create a result object from the cache (usually fast).
+        * You can just 'return cache;' here,
+        * but in some cases you might want to call copy constructors or something
+        * similar so that the cache entry is not modified by users of the returned object.
+        *
+        * @param cache cached result of computeCacheEntry()
+        * @return result object
+        */
+       abstract public ResultType getCachedResult(CacheType cache);
+    }
+    /**
+     * start a new computation it is not currently running
+     *
+     * @return thread object of the running (or newly started) thread
+     */
+    private Thread startOrGetRunningThread() {
+        Thread currentThread;
+        synchronized (lockThread) {
+            if (thread == null || !thread.isAlive()) {
+                thread = new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        // fetch response, overwrite cache
+                        // overwriting reference variables is atomic, so no need for synchronisation here
+                        // this variable is only written by this thread, which has at most one running instance
+                        // it is read concurrently. If someone reads the old cache (which should not happen), nothing bad will occur.
+                        cache = computation.computeCacheEntry();
+                    }
+                });
+                thread.start();
+            }
+            currentThread = thread;
+        }
+        return currentThread;
+    }
+
+    /**
+     * start a new computation it is not currently running
+     */
+    public void renew() {
+        startOrGetRunningThread();
+    }
+    
+    /**
+     * start a new computation it is not currently running, wait until a new result is finished
+     */
+    public void renewBlocking() {
+        try {
+            startOrGetRunningThread().join();
+        } catch (InterruptedException ex) {
+            Logger.getLogger(CachingAsynchronousHandler.class.getName()).log(Level.SEVERE, null, ex);
+            System.exit(1);
+        }
+    }
+
+    /**
+     * start a new computation, if it is not already running, wait for the result and return it.
+     * This method is blocking.
+     * @return cached result that is up-to-date (computation has just finished)
+     */
+    public ResultType getFreshResultBlocking() {
+        try {
+            // wait until fetching is finished
+            startOrGetRunningThread().join();
+        } catch (InterruptedException ex) {
+            // this must not happen
+            Logger.getLogger(VisiCamServer.class.getName()).log(Level.SEVERE, null, ex);
+            System.exit(1);
+        }
+        return getCachedResult();
+    }
+    
+    /**
+     * return cached result immediately. No new computation will be started.
+     * @return cached result that may be extremely outdated or even null, 
+     */
+    public ResultType getCachedResult() {
+        if (cache == null) {
+            return null;
+        }
+        return computation.getCachedResult(cache);
+    }
+}

--- a/src/com/t_oster/visicam/ResponseCache.java
+++ b/src/com/t_oster/visicam/ResponseCache.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2015 Max Gaukler <development@maxgaukler.de>
+ */
+package com.t_oster.visicam;
+
+import gr.ktogias.NanoHTTPD.Response;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Helper for NanoHTTPD.Response which offers a 'factory' to create copies
+ * (NanoHTTPD.Response itself has no copy constructor)
+ */
+public class ResponseCache {
+
+    private final byte[] data;
+    private Properties header;
+    private String mimeType;
+    private String status;
+
+    /**
+     * initialize cache from a Response object. The given object must not be
+     * modified or used anymore.
+     *
+     * @param r
+     */
+    public ResponseCache(Response r) {
+        mimeType = r.mimeType;
+        status = r.status;
+        header = r.header;
+
+            // convert InputStream to byte array
+        // for this, copy input stream to output stream
+        ByteArrayOutputStream outstream = new ByteArrayOutputStream();
+        byte buf[] = new byte[1024];
+        try {
+
+            while (true) {
+                int len = r.data.read(buf);
+                if (len == -1) {
+                    break;
+                }
+                outstream.write(buf, 0, len);
+            }
+        } catch (IOException ex) {
+            // this must not happen - we have virtual input streams here, no real disk operations that can fail
+            Logger.getLogger(VisiCamServer.class.getName()).log(Level.SEVERE, null, ex);
+            System.exit(1);
+        }
+        data = outstream.toByteArray();
+    }
+
+    /**
+     * get cached entry (threadsafe)
+     *
+     * @return copied Response object for use with gr.ktogias.NanoHTTPD
+     */
+    public Response getResponse() {
+        Response copy = new Response(status, mimeType, new ByteArrayInputStream(data));
+        copy.header = (Properties) header.clone();
+        return copy;
+    }
+}

--- a/src/gr/ktogias/NanoHTTPD.java
+++ b/src/gr/ktogias/NanoHTTPD.java
@@ -118,7 +118,7 @@ public class NanoHTTPD
 	 * HTTP response.
 	 * Return one of these from serve().
 	 */
-	public class Response
+	public static class Response
 	{
 		/**
 		 * Default constructor: response = HTTP_OK, data = mime = 'null'


### PR DESCRIPTION
I spent some time on implementing a special kind of caching, so that multiple concurrent requests are answered with the same response. I'm not sure if this works on Raspi because the intermediate results need some RAM and some copy operations are probably rather CPU expensive.

If the raspi integration is not active, the code now always calculates the homography matrix for the current image, as it did before the raspi integration was merged in. I'd like to explain the reason behind this change: When testing the previous version it was very annoying that even for the smallest possible value of refreshSeconds the homography matrix is calculated for the previous image (because an extra image is being taken) and there is a large delay between updates. Because our camera is attached to the lasercutter lid that often moves a bit, you had to wait a long time until the image was stable and inbetween wrong images were displayed.

I tested the code locally with 6+ VisiCut instances as clients and a dummy shellscript serving four different pictures with different distortion.
