### PR TITLE
Add unit file for systemd

### DIFF
--- a/init-scripts/README.md
+++ b/init-scripts/README.md
@@ -1,21 +1,28 @@
 VisiCam init-scripts
 ====================
 
-Installation Debian
-------------
+Installation using systemd
+---
+
+* copy the unit file `visicam.service` to `/etc/systemd/system/visicam.service`
+* enable the VisiCam unit to run at system start: `systemctl enable visicam.service`
+* start VisiCam: `systemctl start visicam.service`
+
+Installation using init.d
+---
+
+### Debian
 
 * copy the init-script to `/etc/init.d/visicam`
 * mark the new init-script as executable `sudo chmod +x /etc/init.d/visicam`
 * if you want to start VisiCam automatically on system-startup, execute `rc-update.d visicam defaults`
 
-Installation Raspbian
-------------
+### Raspbian
 
 * Use the setup_service_raspbian.sh script in main folder as root
 * It will ask for information and setup the automatic system start accordingly.
 
-Usage
------
+### Usage
 
 ```
 sudo /etc/init.d/visicam {start|stop|status|restart|force-reload}

--- a/init-scripts/visicam.service
+++ b/init-scripts/visicam.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Camera service for VisiCut
+Documentation=https://github.com/t-oster/VisiCam
+Requires=network.target
+After=network.target
+
+[Service]
+Type=simple
+User=visicam
+Group=visicam
+WorkingDirectory=/opt/VisiCam/
+ExecStart=/usr/bin/java -jar dist/VisiCam.jar --nogui --port 9999
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
SysV init is deprecated on modern linux systems. We should add a unit file for systemd.