### PR TITLE
Add "zoom" feature, Minor usability improvements

### DIFF
--- a/html/configPage.html
+++ b/html/configPage.html
@@ -14,20 +14,22 @@
     <img style="max-width: 800px;" id="capture"/>
     <fieldset id="settings">
       <legend>VisiCam Settings:</legend>
+      <p><a href="https://github.com/t-oster/VisiCam/wiki/Configuration">Help</a></p>
       <p><label for="cameraIndex">CameraIndex:</label><input id="cameraIndex" name="cameraIndex" type="number" value="0"/></p>
       <p><label for="inputWidth">InputWidth:</label><input id="inputWidth" name="inputWidth" type="number"  value="640"/></p>
       <p><label for="inputHeight">InputHeight:</label><input id="inputHeight" name="inputHeight" type="number" value="480"/></p>
       <p><label for="outputWidth">OutputWidth:</label><input id="outputWidth" name="outputWidth" type="number" value="640"/></p>
       <p><label for="outputHeight">OutputHeight:</label><input id="outputHeight" name="outputHeight" type="number" value="480"/></p>
+      <p><label for="outputWidth">Zoom Output (%):</label><input id="zoomOutputPercent" name="zoomOutputPercent" type="number" value="100" min="1" max="100000"/></p>
       <p><label for="refreshSeconds">RefreshSeconds:</label><input id="refreshSeconds" name="refreshSeconds" type="number" value="1"/></p>
-      <p><label for="lockInsecureSettings">lockInsecureSettings:</label><input id="lockInsecureSettings" name="lockInsecureSettings" type="checkbox"/>(set customCapture, captureCommand and captureResult read-only.<br>If this is disabled, anyone can execute arbitrary commands as the user running VisiCam!<br> once enabled, this can only be disabled from config file)</p>
+      <p><label for="lockInsecureSettings">lockInsecureSettings:</label><input id="lockInsecureSettings" name="lockInsecureSettings" type="checkbox"/><br>(set customCapture, captureCommand and captureResult read-only.<br>If this is disabled, anyone can execute arbitrary commands as the user running VisiCam!<br> once enabled, this can only be disabled from config file)</p>
       <hr>
       <p><label for="customCapture">CustomCapture:</label><input id="customCapture" name="customCapture" type="checkbox"/></p>
       <p class="custom"><label for="captureCommand">CaptureCommand:</label><input id="captureCommand" name="captureCommand" type="text"/></p>
       <p class="custom"><label for="captureResult">CaptureResult:</label><input id="captureResult" name="captureResult" type="text"/></p>
       <hr>
       <!-- visicamRPiGPU integration start -->
-      <p><label for="visicamRPiGPUEnabled">visicamRPiGPU:</label><input id="visicamRPiGPUEnabled" name="visicamRPiGPUEnabled" type="checkbox"/></p>
+      <p><label for="visicamRPiGPUEnabled">visicamRPiGPU (do not use, currently broken):</label><input id="visicamRPiGPUEnabled" name="visicamRPiGPUEnabled" type="checkbox"/></p>
       <p class="visicamRPiGPU"><label for="visicamRPiGPUInactivitySeconds">InactivitySeconds:</label><input id="visicamRPiGPUInactivitySeconds" name="visicamRPiGPUInactivitySeconds" type="number"/></p>
       <p class="visicamRPiGPU"><label for="visicamRPiGPUBinaryPath">BinaryPath:</label><input id="visicamRPiGPUBinaryPath" name="visicamRPiGPUBinaryPath" type="text"/></p>
       <p class="visicamRPiGPU"><label for="visicamRPiGPUMatrixPath">MatrixPath:</label><input id="visicamRPiGPUMatrixPath" name="visicamRPiGPUMatrixPath" type="text"/></p>
@@ -35,15 +37,19 @@
       <p class="visicamRPiGPU"><label for="visicamRPiGPUImageProcessedPath">FinalImagePath:</label><input id="visicamRPiGPUImageProcessedPath" name="visicamRPiGPUImageProcessedPath" type="text"/><br><br>For visicamRPiGPU ensure that: InputWidth == OutputWidth, InputHeight == OutputHeight,<br>enough GPU split memory in raspi-config (1280x720 => 128 MB),<br>width in [640, 1920], height in [480, 1080],<br>width multiple of 32, height multiple of 16,<br>InactivitySeconds > RefreshSeconds</p>
       <hr>
       <!-- visicamRPiGPU integration end -->
-      <p><label for="marker">Marker:</label>
+      <p><label for="marker">Edit Marker:</label>
       <p><select id="marker">
         <option value="0" selected="selected">top-left</option>
         <option value="1">top-right</option>
         <option value="2">bottom-left</option>
         <option value="3">bottom-right</option>
-      </select></p>
-      <button id="save">Save</button>
+        </select><br>
+        Click and drag in the left image to select the marker area.
+      </p>
+      <button id="save">Save</button> 
+      <a href="index.html"> Back to main page </a>
     </fieldset>
+    <p style="clear:both"></p>
     <script type="text/javascript">
     var activeMarker = 0;
     var settings = {};
@@ -68,6 +74,7 @@
       $("#outputWidth").val(settings.outputWidth);
       $("#outputHeight").val(settings.outputHeight);
       $("#refreshSeconds").val(settings.refreshSeconds);
+      $("#zoomOutputPercent").val(settings.zoomOutputPercent);
       $("#lockInsecureSettings").attr("checked",settings.lockInsecureSettings);
 
       // visicamRPiGPU integration start
@@ -200,6 +207,7 @@
       settings.outputWidth = $("#outputWidth").val();
       settings.outputHeight = $("#outputHeight").val();
       settings.refreshSeconds = $("#refreshSeconds").val();
+      settings.zoomOutputPercent = $("#zoomOutputPercent").val();
       settings.captureCommand = $("#customCapture").is(":checked") ? $("#captureCommand").val() : "";
       settings.captureResult = $("#customCapture").is(":checked") ? $("#captureResult").val() : "";
       settings.lockInsecureSettings = $("#lockInsecureSettings").is(":checked");

--- a/html/index.html
+++ b/html/index.html
@@ -7,9 +7,10 @@
     <script type="text/javascript" src="lib/jquery.imgareaselect-0.9.9/scripts/jquery.min.js"></script>  
   </head>
   <body>
-    <h1>VisiCam Version 0.1</h1>
+    <h1>VisiCam</h1>
     <p>Serving your Lasercutter Camera for all <a href="http://visicut.org" target="_blank">VisiCut</a> instances in your Network</p>
-    <img class="logo" src="icon.png"/>
+    <p><a href="https://github.com/t-oster/VisiCam/wiki">Help</a></p>
+    <img class="logo" src="icon.png" alt=""/>
     
     <fieldset id="input">
       <legend>Input Image:</legend>

--- a/html/style.css
+++ b/html/style.css
@@ -10,10 +10,12 @@ body {
   border: 1px solid black;
   border-radius: 5px;
   box-shadow: 3px 1px 5px 0px white;
-  background: silver;
+  background: #F9F9FA;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif;
   position:relative;
   padding-left: 10px;
   padding-bottom: 10px;
+  min-height: 100%;
 }
 
 #input {
@@ -54,4 +56,8 @@ body {
   text-align: left;
   margin-right: 0.5em;
   display: block
+}
+
+#settings p, #settings hr {
+    clear: left; // clear float of previous label
 }

--- a/src/com/t_oster/visicam/VisiCamServer.java
+++ b/src/com/t_oster/visicam/VisiCamServer.java
@@ -51,6 +51,7 @@ public class VisiCamServer extends NanoHTTPD
   private long lastRefreshTime = 0;
   private long lastRequestTime = System.nanoTime();
   private boolean lockInsecureSettings = false;
+  private float zoomOutputPercent = 100;
   
   
   private Thread refreshHomographyThread;
@@ -172,6 +173,7 @@ public class VisiCamServer extends NanoHTTPD
     settings.put("captureCommand", captureCommand);
     settings.put("captureResult", captureResult);
     settings.put("lockInsecureSettings", lockInsecureSettings);
+    settings.put("zoomOutputPercent", zoomOutputPercent);
 
     // visicamRPiGPU integration start
     settings.put("visicamRPiGPUInactivitySeconds", visicamRPiGPUInactivitySeconds);
@@ -199,6 +201,7 @@ public class VisiCamServer extends NanoHTTPD
     outputHeight = Integer.parseInt(parms.getProperty("outputHeight"));
     refreshSeconds = Integer.parseInt(parms.getProperty("refreshSeconds"));
     lockInsecureSettings = Boolean.parseBoolean(parms.getProperty("lockInsecureSettings"));
+    zoomOutputPercent = Float.parseFloat(parms.getProperty("zoomOutputPercent", "100"));
     captureCommand = parms.getProperty("captureCommand");
     captureResult = parms.getProperty("captureResult");
 
@@ -226,6 +229,10 @@ public class VisiCamServer extends NanoHTTPD
     if (refreshSeconds < 10)
     {
         refreshSeconds = 10;
+    }
+    
+    if (zoomOutputPercent < 1) {
+        zoomOutputPercent = 1;
     }
 
     // visicamRPiGPU integration start
@@ -727,7 +734,7 @@ public class VisiCamServer extends NanoHTTPD
 
                             // Update homography matrix with new marker positions
                             // VisiCam.log("Updating homography matrix...");
-                            cc.updateHomographyMatrix(img, currentMarkerPositions, outputWidth, outputHeight, visicamRPiGPUEnabled, visicamRPiGPUMatrixPath);
+                            cc.updateHomographyMatrix(img, currentMarkerPositions, zoomOutputPercent, outputWidth, outputHeight, visicamRPiGPUEnabled, visicamRPiGPUMatrixPath);
 
                             // Log message and set timer
                             VisiCam.log("Refreshed successfully...");


### PR DESCRIPTION
To use the area outside the markers in the output image, you can now set the zoom to <100%. This is required e.g. if there is not enough space above the laser bed, so the top edge of the top-left marker is below the top edge of the laser bed -- with the new setting, you can still see the whole laser bed; before, the area above the top-left marker was cut off.

Also I made the configuration web page look a little more friendly, added help links etc.

Tested in our lab, everything works fine.